### PR TITLE
[Bug] add missing feedbackInputStyle to widget from nps_survey

### DIFF
--- a/lib/nps_survey.dart
+++ b/lib/nps_survey.dart
@@ -45,7 +45,8 @@ class NPSSurvey {
             submitButtonTextStyle: submitButtonTextStyle,
             feedbackInputTextStyle: feedbackInputTextStyle,
             submitButtonStyle: submitButtonStyle,
-            selectedScoreVisible: selectedScoreVisible);
+            selectedScoreVisible: selectedScoreVisible,
+            feedbackInputStyle: feedbackInputStyle);
       },
     );
   }


### PR DESCRIPTION
# Description
This PR addresses an issue where the feedbackInputStyle was not passed to the widget. The omission caused the widget to use the default styling instead of the intended feedbackInputStyle, leading to inconsistent appearance or behavior.

# Fix
The feedbackInputStyle has now been properly passed to the widget, ensuring that the desired styles are applied as expected.